### PR TITLE
Google doesn't ship anymore x64 distribution of Chrome for Debian

### DIFF
--- a/tasks/setup-apt.yml
+++ b/tasks/setup-apt.yml
@@ -4,10 +4,17 @@
 - name: "apt | ensure Google linux signing key present"
   apt_key: url=https://dl-ssl.google.com/linux/linux_signing_key.pub state=present
 
+- name: "apt | ensure previous repository for Google Chrome is absent, as Google removed the x86 distribution"
+  apt_repository: repo='deb http://dl.google.com/linux/chrome/deb/ stable main' state=absent
 
-- name: "apt | ensure Google chrome repo present"
-  apt_repository: repo='deb http://dl.google.com/linux/chrome/deb/ stable main' state=present
+- name: "apt | ensure Google chrome repo present, using a workaround for missing x86 distribution"
+  copy:
+    content: "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main"
+    dest: "/etc/apt/sources.list.d/google-chrome.list"
+  register: google_repo
 
+- name: "apt | update cache"
+  apt: update_cache='{{ google_repo | changed }}'
   
 - name: "apt | ensure Google chrome present"
   apt: name=google-chrome-stable update_cache=yes


### PR DESCRIPTION
Hello,

Google changed their distribution of Chrome for Debian, and I bumped into this problem after doing apt-get update: 

Failed to fetch http://dl.google.com/linux/chrome/deb/dists/stable/Release 
Unable to find expected entry 'main/binary-i386/Packages' in Release file (Wrong sources.list entry or malformed file) 
Some index files failed to download. They have been ignored, or old ones used instead.

The solution was given here, and I have implemented it for this role
http://www.webupd8.org/2016/03/fix-failed-to-fetch-google-chrome_3.html
