### PR TITLE
Fix TypeError in apt cache update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 language: python
 python: "2.7"
+sudo: required
+dist: trusty
 before_install:
  - sudo apt-get update -qq
 install:

--- a/tasks/setup-apt.yml
+++ b/tasks/setup-apt.yml
@@ -14,7 +14,8 @@
   register: google_repo
 
 - name: "apt | update cache"
-  apt: update_cache='{{ google_repo | changed }}'
+  apt: update_cache=yes
+  when: google_repo.changed
   
 - name: "apt | ensure Google chrome present"
   apt: name=google-chrome-stable update_cache=yes


### PR DESCRIPTION
When running this role multiple times (or when the chrome repository is already installed), cache update fails in Ansible 2.0.0.2 with a TypeError: 'NoneType' object is not iterable. Skipping the cache update when the repository is already installed resolves this issue.
