### PR TITLE
Streamlining & Ignore failures in check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,7 @@
 ---
 # tasks file for ansible-role-chrome
 
-
-- include: setup-apt.yml
+- include: "setup-{{ ansible_pkg_mgr }}.yml"
   when: ansible_pkg_mgr == 'apt'
-
-- include: setup-dnf.yml
-  when: ansible_pkg_mgr == 'dnf'
-
+        or ansible_pkg_mgr == 'dnf'
 ...

--- a/tasks/setup-apt.yml
+++ b/tasks/setup-apt.yml
@@ -25,6 +25,7 @@
 - name: "apt | ensure Google chrome present"
   apt: 
     name: "google-chrome-stable"
+    state: "present"
     update_cache: "yes"
     cache_valid_time: "3600" # only update cache if it hasn't been updated in 1 hour
   ignore_errors: '{{ ansible_check_mode }}' # ignoring in --check, this will fail due to pre-reqs

--- a/tasks/setup-apt.yml
+++ b/tasks/setup-apt.yml
@@ -17,7 +17,7 @@
     dest: "/etc/apt/sources.list.d/google-chrome.list"
   register: google_repo
 
-- name: "apt | update cache"
+- name: "apt | update cache if the Google Chrome repo has been changed"
   apt: 
     update_cache: "yes"
   when: google_repo.changed
@@ -26,6 +26,7 @@
   apt: 
     name: "google-chrome-stable"
     update_cache: "yes"
+    cache_valid_time: "3600" # only update cache if it hasn't been updated in 1 hour
   ignore_errors: '{{ ansible_check_mode }}' # ignoring in --check, this will fail due to pre-reqs
 
 ...

--- a/tasks/setup-apt.yml
+++ b/tasks/setup-apt.yml
@@ -26,5 +26,6 @@
   apt: 
     name: "google-chrome-stable"
     update_cache: "yes"
+  ignore_errors: '{{ ansible_check_mode }}' # ignoring in --check, this will fail due to pre-reqs
 
 ...

--- a/tasks/setup-apt.yml
+++ b/tasks/setup-apt.yml
@@ -2,10 +2,14 @@
 # via http://linuxg.net/how-to-install-google-chrome-42-stable-on-the-most-popular-linux-systems-via-the-official-google-repository/
 
 - name: "apt | ensure Google linux signing key present"
-  apt_key: url=https://dl-ssl.google.com/linux/linux_signing_key.pub state=present
+  apt_key: 
+    url: "https://dl-ssl.google.com/linux/linux_signing_key.pub"
+    state: "present"
 
 - name: "apt | ensure previous repository for Google Chrome is absent, as Google removed the x86 distribution"
-  apt_repository: repo='deb http://dl.google.com/linux/chrome/deb/ stable main' state=absent
+  apt_repository: 
+    repo: 'deb http://dl.google.com/linux/chrome/deb/ stable main'
+    state: "absent"
 
 - name: "apt | ensure Google chrome repo present, using a workaround for missing x86 distribution"
   copy:
@@ -14,10 +18,13 @@
   register: google_repo
 
 - name: "apt | update cache"
-  apt: update_cache=yes
+  apt: 
+    update_cache: "yes"
   when: google_repo.changed
   
 - name: "apt | ensure Google chrome present"
-  apt: name=google-chrome-stable update_cache=yes
+  apt: 
+    name: "google-chrome-stable"
+    update_cache: "yes"
 
 ...


### PR DESCRIPTION
I made some changes to streamline this for my Ubuntu system so I figured I would share them.  If this isn't where you want to take this role, feel free to ignore this.  (I don't have a Fedora system to test with, so I left the dnf side alone.)

- Converted to multiline, native yaml syntax
- Changed it so the apt cache is only updated when needed:
  - When the google chrome repo is changed
  - or if it hasn't been updated in more than an hour
- Modified the main task file so it only includes the setup file for the current package manager, so it no longer shows the skipped tasks for the other package manager

Thanks,
-Todd