### PR TITLE
Fix deprecation warning in main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,10 +2,10 @@
 # tasks file for ansible-role-chrome
 
 
-- include: setup-apt.yml
+- include_tasks: setup-apt.yml
   when: ansible_pkg_mgr == 'apt'
 
-- include: setup-dnf.yml
+- include_tasks: setup-dnf.yml
   when: ansible_pkg_mgr == 'dnf'
 
 ...


### PR DESCRIPTION
```
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16.
```