### PR TITLE
Convert `include` to `include_tasks` for ansible-core 2.16 compatibility

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,10 +2,10 @@
 # tasks file for ansible-role-chrome
 
 
-- include: setup-apt.yml
+- include_tasks: setup-apt.yml
   when: ansible_pkg_mgr == 'apt'
 
-- include: setup-dnf.yml
+- include_tasks: setup-dnf.yml
   when: ansible_pkg_mgr == 'dnf'
 
 ...


### PR DESCRIPTION
Trying to use the role with Ansible 9 (using `ansible-core` 2.16), I get an error:
```
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```

This PR should fix it.